### PR TITLE
[WIP] Weighted random seed selection

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1393,7 +1393,7 @@ static void cull_queue(void) {
 
   q = queue;
 
-  while (q) {    
+  while (q) {
     q->favored = 0;
     q = q->next;
   }
@@ -1422,9 +1422,9 @@ static void cull_queue(void) {
   q = queue;
 
   while (q) {
-    mark_as_redundant(q, !q->favored);    
+    mark_as_redundant(q, !q->favored);
     q = q->next;
-  }  
+  }
 
 }
 
@@ -8122,8 +8122,6 @@ int main(int argc, char** argv) {
     u8 skipped_fuzz;
 
     cull_queue();
-
-    
 
     if (!queue_cur) {
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1345,7 +1345,7 @@ static void mark_selected_inputs() {
     if (q->favored) {
       w *= 20.0;
     } else if (!q->was_fuzzed) {
-      w *= 5.0;
+      w *= 1.0; // based on the experiments, 1.0 outperforms 5.0 (which is the original probabilities to fuzz brand new inputs in AFL)
     }
 
     q->is_selected = 0; // reset flag from previous cycle

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1315,7 +1315,7 @@ double rand_double()
 }
 
 // find the first element in array that is greater or equal target
-int first_greater_or_equal_element(double arr[], double target, int end)
+int first_greater_element(double arr[], double target, int end)
 {
     int lo = 0;
     int hi = end;
@@ -1359,7 +1359,7 @@ static void mark_selected_inputs() {
   while (total_selected < 64) {
     // find random number and search this number in the array
     double r = rand_double() * total_weight; 
-    int seed_idx = first_greater_or_equal_element(cumulative_sum, r, queued_paths);
+    int seed_idx = first_greater_element(cumulative_sum, r, queued_paths);
     if (queue_list[seed_idx]->is_selected)
       break;
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1353,6 +1353,7 @@ static void mark_selected_inputs() {
     queue_list[idx] = q;
     cumulative_sum[idx] = total_weight;
     q = q->next;
+    idx++;
   }
 
   int total_selected = 0;


### PR DESCRIPTION
@wuestholz, this PR adds new input selection mechanism that randomly picks inputs to fuzz based on the weight of inputs. 

In AFL the fuzzed inputs are not saved in array but instead a linked list so there is no convenient way to maintain the index of inputs in the queue. This PR adds a new array that keeps track of all inputs so far in the queue.