### PR TITLE
[WIP] Randomize fuzzing params with prob

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1419,11 +1419,23 @@ static void mark_selected_inputs() {
 }
 
 static void reset_fuzzing_params() {
-  custom_havoc_stack_pow2 = HAVOC_STACK_POW2;
+  custom_havoc_cycles       = HAVOC_CYCLES;
+  custom_havoc_stack_pow2   = HAVOC_STACK_POW2;
+  custom_havoc_blk_small    = HAVOC_BLK_SMALL;
+  custom_havok_blk_medium   = HAVOC_BLK_MEDIUM;
+  custom_havoc_blk_large    = HAVOC_BLK_LARGE;
+  custom_splice_cycles      = SPLICE_CYCLES;
+  custom_splice_havoc       = SPLICE_HAVOC;
 }
 
 static void randomize_fuzzing_params() {
-  custom_havoc_stack_pow2 = rand_int_in_range(4, 10);
+  custom_havoc_cycles       = rand_int_in_range(192, 320);
+  custom_havoc_stack_pow2   = rand_int_in_range(4, 10);
+  custom_havoc_blk_small    = rand_int_in_range(24, 40);
+  custom_havok_blk_medium   = rand_int_in_range(96, 160);
+  custom_havoc_blk_large    = rand_int_in_range(1000, 2000);
+  custom_splice_cycles      = rand_int_in_range(10, 20);
+  custom_splice_havoc       = rand_int_in_range(24, 40);
 }
 
 /* The second part of the mechanism discussed above is a routine that
@@ -4905,23 +4917,23 @@ static u32 choose_block_len(u32 limit) {
   switch (UR(rlim)) {
 
     case 0:  min_value = 1;
-             max_value = HAVOC_BLK_SMALL;
+             max_value = custom_havoc_blk_small;
              break;
 
-    case 1:  min_value = HAVOC_BLK_SMALL;
-             max_value = HAVOC_BLK_MEDIUM;
+    case 1:  min_value = custom_havoc_blk_small;
+             max_value = custom_havok_blk_medium;
              break;
 
     default: 
 
              if (UR(10)) {
 
-               min_value = HAVOC_BLK_MEDIUM;
-               max_value = HAVOC_BLK_LARGE;
+               min_value = custom_havok_blk_medium;
+               max_value = custom_havoc_blk_large;
 
              } else {
 
-               min_value = HAVOC_BLK_LARGE;
+               min_value = custom_havoc_blk_large;
                max_value = HAVOC_BLK_XL;
 
              }
@@ -6327,7 +6339,7 @@ havoc_stage:
 
     stage_name  = "havoc";
     stage_short = "havoc";
-    stage_max   = (doing_det ? HAVOC_CYCLES_INIT : HAVOC_CYCLES) *
+    stage_max   = (doing_det ? HAVOC_CYCLES_INIT : custom_havoc_cycles) *
                   perf_score / havoc_div / 100;
 
   } else {
@@ -6339,7 +6351,7 @@ havoc_stage:
     sprintf(tmp, "splice %u", splice_cycle);
     stage_name  = tmp;
     stage_short = "splice";
-    stage_max   = SPLICE_HAVOC * perf_score / havoc_div / 100;
+    stage_max   = custom_splice_havoc * perf_score / havoc_div / 100;
 
   }
 
@@ -6783,7 +6795,7 @@ havoc_stage:
 
 retry_splicing:
 
-  if (use_splicing && splice_cycle++ < SPLICE_CYCLES &&
+  if (use_splicing && splice_cycle++ < custom_splice_cycles &&
       queued_paths > 1 && queue_cur->len > 1) {
 
     struct queue_entry* target;
@@ -8322,10 +8334,15 @@ int main(int argc, char** argv) {
 
       if (!disable_randomized_fuzzing_params) {
         // randomize fuzzing params with probabilities
-        if (UR(100) < randomize_parameters_prob)
+        OKF("WEASDASDASD %d", randomize_parameters_prob);
+        if (UR(100) < randomize_parameters_prob) {
           randomize_fuzzing_params();
-        else
+          OKF("YES RANDOM!!!");
+        }
+        else {
           reset_fuzzing_params();
+          OKF("NO RANDOM!!");
+        }
       }
 
       show_stats();

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8343,7 +8343,6 @@ int main(int argc, char** argv) {
       if (!disable_weighted_random_selection)
         mark_selected_inputs();
 
-
       show_stats();
 
       if (not_on_tty) {

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8334,15 +8334,10 @@ int main(int argc, char** argv) {
 
       if (!disable_randomized_fuzzing_params) {
         // randomize fuzzing params with probabilities
-        OKF("WEASDASDASD %d", randomize_parameters_prob);
-        if (UR(100) < randomize_parameters_prob) {
+        if (UR(100) < randomize_parameters_prob)
           randomize_fuzzing_params();
-          OKF("YES RANDOM!!!");
-        }
-        else {
+        else
           reset_fuzzing_params();
-          OKF("NO RANDOM!!");
-        }
       }
 
       show_stats();

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -44,6 +44,7 @@
 #include "hash.h"
 
 #include <stdio.h>
+#include <math.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1287,10 +1287,8 @@ double rand_double()
 }
 
 int rand_int_in_range(int low, int high) {
-    double rnd = rand() / (1.0 + RAND_MAX);
     int range = high - low + 1;
-    int rnd_scaled = (rnd * range) + low;
-    return rnd_scaled;
+    return low + UR(range);
 }
 
 /* When we bump into a new path, we call this to see if the path appears

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -44,7 +44,6 @@
 #include "hash.h"
 
 #include <stdio.h>
-#include <math.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
@@ -5272,7 +5271,7 @@ static u8 fuzz_one(char** argv) {
   // assign probability based on frequncy that the seed was chosen
   if (!disable_randomized_fuzzing_params) {
     // randomize fuzzing params with probabilities
-    int multiplier = queue_cur->num_fuzzed ? ceil(queue_cur->num_fuzzed/5000.0): 0;
+    int multiplier = queue_cur->num_fuzzed ? ((int)(queue_cur->num_fuzzed/5000.0)) + 1: 0;
     randomize_parameters_prob = MIN(MAX(multiplier * 5, 5), 75);
     if (UR(100) < randomize_parameters_prob)
       randomize_fuzzing_params();

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5268,6 +5268,17 @@ static u8 fuzz_one(char** argv) {
     fflush(stdout);
   }
 
+  // assign probability based on frequncy that the seed was chosen
+  if (!disable_randomized_fuzzing_params) {
+    // randomize fuzzing params with probabilities
+    int multiplier = queue_cur->num_fuzzed ? ceil(queue_cur->num_fuzzed/5000.0): 0;
+    randomize_parameters_prob = MIN(MAX(multiplier * 5, 5), 75);
+    if (UR(100) < randomize_parameters_prob)
+      randomize_fuzzing_params();
+    else
+      reset_fuzzing_params();
+  }
+
   /* Map the test case into memory. */
 
   fd = open(queue_cur->fname, O_RDONLY);
@@ -8332,13 +8343,6 @@ int main(int argc, char** argv) {
       if (!disable_weighted_random_selection)
         mark_selected_inputs();
 
-      if (!disable_randomized_fuzzing_params) {
-        // randomize fuzzing params with probabilities
-        if (UR(100) < randomize_parameters_prob)
-          randomize_fuzzing_params();
-        else
-          reset_fuzzing_params();
-      }
 
       show_stats();
 


### PR DESCRIPTION
This PR randomly adjusts AFL's fuzzing parameters which typically are constants. Basically at the beginning of the fuzzing cycle, we repeatedly randomize parameter's value with some probabilities that can be set with env variable `AFL_RP_PROB`. 